### PR TITLE
Mecab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,17 @@ gem "nokogiri", "~> 1.14", ">= 1.14.2"
 # mecab gem
 # gem 'mecab'
 
+# the suika gem for tokenization, less problems getting it running than natto and mecab
+# It runs on pure ruby, based on mecab. No need to install anything else
+# see documentation on github for how to use
+gem 'suika'
+# this is the gem that allows quick parsing of the japanese english dictionary
+# the JMdict
+# Using this we can create a dictionary for our use
+gem 'eiwa'
+
+
+
 # Faker gem
 gem "faker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    dartsclone (0.3.2)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -117,6 +118,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    eiwa (0.1.0)
+      nokogiri
     epub-cfi (0.1.2)
     epub-parser (0.4.6)
       addressable (>= 2.3.5)
@@ -253,6 +256,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    suika (0.3.2)
+      dartsclone (>= 0.2.0)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -297,6 +302,7 @@ DEPENDENCIES
   deepl-rb
   devise
   dotenv-rails
+  eiwa
   epub-parser
   faker
   font-awesome-sass (~> 6.1)
@@ -313,6 +319,7 @@ DEPENDENCIES
   simple_form!
   sprockets-rails
   stimulus-rails
+  suika
   turbo-rails
   tzinfo-data
   web-console

--- a/app/services/japanest_to_english_dictionary.rb
+++ b/app/services/japanest_to_english_dictionary.rb
@@ -1,0 +1,19 @@
+class JapaneseToEnglishDictionary
+  def initialize
+    @dictionary = {}
+    Eiwa.parse_file("lib/assets/dictionaries/JMdict_e.xml", type: :jmdict_e) do |entry|
+      if !entry.spellings.first.nil?
+        japanese = entry.spellings.first.text
+      end
+      if !entry.meanings.first.definitions.first.nil?
+        english =  entry.meanings.first.definitions.first.text
+      end
+      if english && japanese
+        @dictionary[japanese] = english
+      end
+      # TODO ADD FURIGANA FROM DICTIONARY
+      # CHECK IF THIS IS FEASABLE ON LIVE
+      # SEE IF THE DICTIONARY CAN'T BE ACCESSED FROM A CONSTANT
+    end
+  end
+end

--- a/app/services/japanest_to_english_dictionary.rb
+++ b/app/services/japanest_to_english_dictionary.rb
@@ -2,12 +2,14 @@ class JapaneseToEnglishDictionary
   def initialize
     @dictionary = {}
     Eiwa.parse_file("lib/assets/dictionaries/JMdict_e.xml", type: :jmdict_e) do |entry|
+      # possibility of nil exists, this checks for that
       if !entry.spellings.first.nil?
         japanese = entry.spellings.first.text
       end
       if !entry.meanings.first.definitions.first.nil?
         english =  entry.meanings.first.definitions.first.text
       end
+      # only allow it to be added to hash if both exist
       if english && japanese
         @dictionary[japanese] = english
       end


### PR DESCRIPTION
Created quick service so we can take the JMDict and turn it into a hash based dictionary in the app. Will need to test to see if it's feasible memory wise, or a waste of time. Also found and added gems suika, and eiwa. Eiwa is for parsing JMdict, and suika is a pure ruby based alternative to mecab, based on mecab, that parses japanese text.
