### PR TITLE
made the suika tagger a constant that can be called

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,7 @@
 require "open-uri"
 
 class BooksController < ApplicationController
+
   def index
     @books = policy_scope(Book)
     @book = Book.new()
@@ -46,6 +47,7 @@ class BooksController < ApplicationController
   end
 
   def create
+
     @book = Book.new(book_params)
 
     title = "processing"

--- a/app/services/english_filter.rb
+++ b/app/services/english_filter.rb
@@ -42,33 +42,30 @@ class EnglishFilter
     singular_words = @singular_words.map{ |word| word.downcase}
     singular_words -= @stop_words
     singular_words -= @top_names
-    split_text =  singular_words - @contractions
-    split_clean = split_text.map {|word| word.gsub(/(\W|\d)/, "")}
+    singular_words -= @contractions
+    singular_words.map! {|word| word.gsub(/(\W|\d)/, "")}
     # split_text = text.split(/(\\n)|[\s\-\_\/]/)
     # gets rid of non letters
     # makes all words singular
-    words = split_clean.map {|word| word.singularize}
+    singular_words.map! {|word| word.singularize}
     # reject 1 and 2 letter words
-    words = words.reject{|w| w.length.between?(1,2)}
+    singular_words.reject!{|w| w.length.between?(1,2)}
     # downcase the words
-    unique_words = words.uniq
-    unique_words = unique_words.reject {|word| word.empty?}
+    unique_words = singular_words.uniq
+    unique_words.reject! {|word| word.empty?}
     # make a hash with word count
     # in case of nil, compact!
     unique_words.compact!
-    @contractions.each do |word|
+    contractions_two = @contractions.map {|word| word.gsub("n't", "")}
+    unique_words -= contractions_two
       # noticed a pattern in dracula,
       # where contractions lose the t to make
-      # an accent. This accounts for some of that
-      word = word.gsub("n't", "")
-      unique_words = unique_words.reject {|unique| unique.include?(word)}
-    end
     # get rid of most common english words
     unique_words -= @english_10000
 
     unique_array = unique_words.map do |unique|
       {
-        count: words.count(unique),
+        count: singular_words.count(unique),
         word: unique
       }
     end

--- a/app/services/text_tokenizer_japanese.rb
+++ b/app/services/text_tokenizer_japanese.rb
@@ -1,7 +1,6 @@
 class TextTokenizerJapanese
   def initialize(array)
     @array = array
-    @tagger = Suika::Tagger.new
     # this regex finds japanese
     # katakana, hiragana, and kanji
     # and ignores most punctuation
@@ -18,7 +17,7 @@ class TextTokenizerJapanese
   end
 
   def tokenize(text)
-    @tagger.parse(text).map do |word|
+    TAGGER.parse(text).map do |word|
       spliced = word.split("\t").last.split(",")
       {
         origin_word: spliced[6],

--- a/config/initializers/suika_tagger.rb
+++ b/config/initializers/suika_tagger.rb
@@ -1,0 +1,1 @@
+TAGGER = Suika::Tagger.new


### PR DESCRIPTION
Turns out the gem likes to call its mecab binary library every time it's initialized. While this is handled fine on my mac, it probably is intensive for the limited ram on the heroku server. Setting it as a constant during initialization and simply calling a single instance over and over again should save processing power